### PR TITLE
feat: implement event loading from local storage & restyle event cards

### DIFF
--- a/frontend/src/components/EventCard.tsx
+++ b/frontend/src/components/EventCard.tsx
@@ -1,34 +1,51 @@
+import { Dispatch } from "react";
+import { EventActions } from "@/pages";
+import Link from "next/link";
+
 export type GenericEvent = {
   id: string;
   title: string;
   location: string;
   date: string;
   time: string;
+  url: string;
 };
 
 type EventCardProps = {
   event: GenericEvent;
   eventSaved: boolean;
-  removeEvent: (id: string) => void;
+  eventStateDispatch: Dispatch<EventActions>;
 };
 
 export const EventCard = ({
   event,
   eventSaved,
-  removeEvent,
+  eventStateDispatch,
 }: EventCardProps) => {
   const buttonTerm = eventSaved ? "Remove" : "Save";
 
-  // wrap handler with id context
-  const handleRemoveEvent = () => removeEvent(event.id);
+  // wrap dispatch with id context
+  const handleRemoveEvent = () =>
+    eventStateDispatch({
+      type: "REMOVE",
+      payload: {
+        id: event.id,
+      },
+    });
 
   return (
     <div
-      className="grid grid-cols-[auto_auto] place-items-start place-content-between px-6 py-4 bg-gray-50/90 border border-gray-300  shadow-sm rounded-md text-gray-950"
+      className="hover:border-gray-400/60 grid grid-cols-[auto_auto] place-items-start place-content-between px-6 py-4 bg-gray-50/90 border border-gray-300 transition-all duration-200 hover:shadow-md shadow-sm rounded-md text-gray-950 "
       key={event.id}
     >
       <div className="flex flex-col w-max">
-        <p className="text-xl font-black">{event.title}</p>
+        <Link
+          target="_blank"
+          href={event.url}
+          className="pr-4 text-xl font-black w-fit hover:underline underline-offset-2"
+        >
+          {event.title}
+        </Link>
         <p>{event.location}</p>
         <p>{event.date}</p>
         <p>{event.time}</p>

--- a/frontend/src/components/EventCard.tsx
+++ b/frontend/src/components/EventCard.tsx
@@ -1,0 +1,44 @@
+export type GenericEvent = {
+  id: string;
+  title: string;
+  location: string;
+  date: string;
+  time: string;
+};
+
+type EventCardProps = {
+  event: GenericEvent;
+  eventSaved: boolean;
+  removeEvent: (id: string) => void;
+};
+
+export const EventCard = ({
+  event,
+  eventSaved,
+  removeEvent,
+}: EventCardProps) => {
+  const buttonTerm = eventSaved ? "Remove" : "Save";
+
+  // wrap handler with id context
+  const handleRemoveEvent = () => removeEvent(event.id);
+
+  return (
+    <div
+      className="grid grid-cols-[auto_auto] place-items-start place-content-between px-6 py-4 bg-gray-50/90 border border-gray-300  shadow-sm rounded-md text-gray-950"
+      key={event.id}
+    >
+      <div className="flex flex-col w-max">
+        <p className="text-xl font-black">{event.title}</p>
+        <p>{event.location}</p>
+        <p>{event.date}</p>
+        <p>{event.time}</p>
+      </div>
+      <button
+        onClick={handleRemoveEvent}
+        className="px-4 py-[0.375rem] text-xs transition-all duration-100 bg-gray-400 rounded-md hover:bg-gray-500 text-white w-min h-min"
+      >
+        {buttonTerm}
+      </button>
+    </div>
+  );
+};

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,4 +1,6 @@
 import { CarIcon, ChevronDown } from "lucide-react";
+
+import { GenericEvent } from "./EventCard";
 import Link from "next/link";
 import React from "react";
 
@@ -7,6 +9,29 @@ type PagePaths = "/" | "/search" | "/results";
 type PageLink = {
   title: string;
   href: PagePaths;
+};
+
+const clearMockEvents = () => {
+  localStorage.removeItem("events");
+};
+
+const addMockEvent = () => {
+  const e: GenericEvent = {
+    id: Math.floor(Math.random() * 1000).toString(),
+    date: Date().toLocaleUpperCase(),
+    location: "Test Location",
+    time: "Test Time",
+    title: `Test Event ${Math.floor(Math.random() * 1000000)}`,
+    url: "https://www.umass.edu/",
+  };
+
+  const eventsFromStorage = localStorage.getItem("events") ?? "";
+
+  const pastEvents = eventsFromStorage.length
+    ? JSON.parse(eventsFromStorage)
+    : [];
+
+  localStorage.setItem("events", JSON.stringify([...pastEvents, e]));
 };
 
 const pages: Record<string, PageLink> = {
@@ -37,6 +62,20 @@ const Navbar = () => {
       </Link>
       {/* LINKS */}
       <ul className="flex gap-8 my-auto">
+        <li className="relative">
+          <button className="flex items-center gap-2 py-2 transition-colors duration-150 text-neutral-900 hover:text-sky-600 peer">
+            DEV TOOLS
+            <ChevronDown />
+          </button>
+          <ul className="hover:flex absolute hidden px-6 pr-12 gap-4 py-5 text-left flex-col rounded-2xl rounded-tr-none shadow-lg w-[16rem] bg-gray-50 top-10 right-3 peer-hover:flex peer-hover:open open:flex">
+            <button onClick={addMockEvent}>
+              <li className="py-2">{"Add Mock Event"}</li>
+            </button>
+            <button onClick={clearMockEvents}>
+              <li className="py-2">{"Clear Mock Event"}</li>
+            </button>
+          </ul>
+        </li>
         <NavLink href={pages.home.href}>
           <li className="py-2">{pages.home.title}</li>
         </NavLink>

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -4,13 +4,14 @@ import type { AppProps } from "next/app";
 import Navbar from "../components/Navbar";
 import { Plus_Jakarta_Sans } from "next/font/google";
 
-const Jakarta = Plus_Jakarta_Sans({ subsets: ["latin"] });
+const font = Plus_Jakarta_Sans({ subsets: ["latin"] });
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
-    <div className={`${Jakarta.className}`}>
+    <div className={`${font.className} min-h-screen flex flex-col`}>
+      {/* <div className={`${Jakarta.className} min-h-screen flex flex-col`}> */}
       <Navbar />
-      <main className="max-w-screen-lg mx-auto text-neutral-900">
+      <main className="w-full max-w-screen-lg px-8 mx-auto text-neutral-900">
         <Component {...pageProps} />
       </main>
     </div>

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -1,126 +1,99 @@
-import { useEffect, useState } from "react";
+import { EventCard, GenericEvent } from "@/components/EventCard";
+import { useEffect, useReducer, useState } from "react";
 
 import Link from "next/link";
 
-type Event = {
-  id: number;
-  title: string;
-  location: string;
-  // change to Date type
-  date: string;
-  time: string;
+export type EventActions =
+  | { type: "REMOVE"; payload: { id: string } }
+  | { type: "ADD"; payload: { event: GenericEvent } }
+  | { type: "LOAD_ALL" };
+
+const eventReducer = (
+  events: GenericEvent[],
+  action: EventActions
+): GenericEvent[] => {
+  switch (action.type) {
+    case "REMOVE":
+      const filteredEvents = events.filter((e) => e.id !== action.payload.id);
+      localStorage.setItem("events", JSON.stringify(filteredEvents));
+      return filteredEvents;
+    case "ADD":
+      const newEvents = [...events, action.payload.event];
+      localStorage.setItem("events", JSON.stringify(newEvents));
+      return newEvents;
+    case "LOAD_ALL":
+      return JSON.parse(localStorage.getItem("events") ?? "[]");
+    default:
+      console.log("default");
+      return events;
+  }
 };
 
-const mockEvents = [
-  {
-    id: 1,
-    title: "Event 1",
-    location: "Event 1 location",
-    date: "Event 1 date",
-    time: "Event 1 time",
-  },
-  {
-    id: 2,
-    title: "Event 2",
-    location: "Event 2 location",
-    date: "Event 2 date",
-    time: "Event 2 time",
-  },
-  {
-    id: 3,
-    title: "Event 3",
-    location: "Event 3 location",
-    date: "Event 3 date",
-    time: "Event 3 time",
-  },
-  {
-    id: 4,
-    title: "Event 4",
-    location: "Event 4 location",
-    date: "Event 4 date",
-    time: "Event 4 time",
-  },
-  {
-    id: 5,
-    title: "Event 5",
-    location: "Event 5 location",
-    date: "Event 5 date",
-    time: "Event 5 time",
-  },
-];
-
-const useEvents = () => {
-  const [events, setEvents] = useState<Event[]>([]);
+// Event State
+const useEventState = () => {
+  const defaultState: GenericEvent[] = [];
+  const [events, dispatchEvents] = useReducer(eventReducer, defaultState);
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    // WILL FETCH FROM LOCAL STORAGE IN FUTURE
     const fetchEvents = async () => {
       setLoading(true);
-      setEvents(() => mockEvents);
-      // setEvents(() => []);
+      dispatchEvents({
+        type: "LOAD_ALL",
+      });
       setLoading(false);
     };
 
     fetchEvents();
   }, []);
 
-  return { events, loading, error };
+  return { events, loading, error, eventStateDispatch: dispatchEvents };
 };
 
 const FindEventsPanel = ({ hasEvents }: { hasEvents: boolean }) => {
-  const buttonText = hasEvents ? "Find More Events" : "Find Events";
-
   const fullScreenStyle =
-    " justify-center items-center my-auto rounded-md bg-[radial-gradient(ellipse_at_left,_var(--tw-gradient-stops))] from-sky-400 to-indigo-900 flex w-full min-h-[25rem]";
+    " justify-center flex-grow items-center my-auto rounded-md bg-[radial-gradient(ellipse_at_left,_var(--tw-gradient-stops))] from-sky-400 to-indigo-900 flex min-h-[30rem]";
   const singleColumnStyle =
     "flex items-center justify-center rounded-md bg-[radial-gradient(ellipse_at_left,_var(--tw-gradient-stops))] from-sky-400 to-indigo-900 w-72";
 
-  const divStyle = hasEvents ? singleColumnStyle : fullScreenStyle;
-
   return (
-    <div className={divStyle}>
+    <div className={hasEvents ? singleColumnStyle : fullScreenStyle}>
       <Link
         href="results"
         className="px-6 py-3 font-medium transition-colors duration-300 rounded-md shadow-md bg-sky-100 hover:bg-sky-50"
       >
-        {buttonText}
+        {hasEvents ? "Find More Events" : "Find Events"}
       </Link>
-    </div>
-  );
-};
-
-const EventsList = ({ events }: { events: Event[] }) => {
-  return (
-    <div className="flex flex-col flex-1 w-auto gap-4">
-      {events.map((e) => (
-        <div
-          className="flex flex-col px-6 py-4 bg-gray-600 rounded-md text-neutral-300"
-          key={e.id}
-        >
-          <p className="text-xl font-black">{e.title}</p>
-          <p>{e.location}</p>
-          <p>{e.date}</p>
-          <p>{e.time}</p>
-        </div>
-      ))}
     </div>
   );
 };
 
 // HOMEPAGE
 export default function Home() {
-  const { events, loading, error } = useEvents();
+  const { events, loading, error, eventStateDispatch } = useEventState();
 
   if (loading) return <p>Loading...</p>;
   if (error) return <p>Error</p>;
 
+  const EventList = () => (
+    <div className="flex flex-col flex-1 w-auto gap-4">
+      {events.map((e) => (
+        <EventCard
+          key={e.id}
+          event={e}
+          eventStateDispatch={eventStateDispatch}
+          eventSaved={true}
+        />
+      ))}
+    </div>
+  );
+
   return (
-    <div className="flex flex-col gap-4 py-12 sm:flex-row ">
+    <div className="flex flex-col h-full gap-6 py-12 sm:flex-row ">
       {events.length ? (
         <>
-          <EventsList events={events} />
+          <EventList />
           <FindEventsPanel hasEvents={true} />
         </>
       ) : (


### PR DESCRIPTION
This PR: 
- Adds dev tools to navbar to create a mock event with mock/random data (just for testing purposes)
- Restyle event cards; said component lives in `src/components/EventCard.tsx`
- Loads events from local storage
  - Stored in local storage as json string (just an array of Event objects)
  - Accessed in local storage under key `"events"
    - ie. `localStorage.getItem("events", <item>)` to access
- Adds remove button to Event cards to remove from application state AND local storage (on home screen/index.tsx)

To Keep in Mind:
- Events **not** sorted right now
  - should be sorted by date (next event at top), but not bothering until we have real events stored
  - Right "Find Events" Column is always as tall as the left column. In other words, if we have less events, that block is small, if we have more events, it's tall. Not sure desired behavior here.